### PR TITLE
Modularizes the functionality, making it simple to extend and configure - even outside of the library itself

### DIFF
--- a/src/DefaultOptions.js
+++ b/src/DefaultOptions.js
@@ -1,4 +1,13 @@
+import DisplaySize from './modules/DisplaySize';
+import Toolbar from './modules/Toolbar';
+import Resize from './modules/Resize';
+
 export default {
+    modules: [
+        DisplaySize,
+        Toolbar,
+        Resize,
+    ],
     overlayStyles: {
         position: 'absolute',
         boxSizing: 'border-box',
@@ -12,7 +21,6 @@ export default {
         boxSizing: 'border-box',
         opacity: '0.80',
     },
-    displaySize: true,
     displayStyles: {
         position: 'absolute',
         font: '12px/1.0 Arial, Helvetica, sans-serif',
@@ -25,7 +33,6 @@ export default {
         opacity: '0.80',
         cursor: 'default',
     },
-    displayToolbar: true,
     toolbarButtons: {
         alignLeft: true,
         alignRight: true,

--- a/src/ImageResize.js
+++ b/src/ImageResize.js
@@ -1,5 +1,11 @@
 import { defaultsDeep } from 'lodash';
 import DefaultOptions from './DefaultOptions';
+
+export { default as BaseModule } from './modules/BaseModule';
+export { default as DisplaySize } from './modules/DisplaySize';
+export { default as Toolbar } from './modules/Toolbar';
+export { default as Resize } from './modules/Resize';
+
 /**
  * Custom module for quilljs to allow user to resize <img> elements
  * (Works on Chrome, Edge, Safari and replaces Firefox's native resize behavior)
@@ -12,17 +18,66 @@ export default class ImageResize {
         this.quill = quill;
 
         // Apply the options to our defaults, and stash them for later
+        // defaultsDeep doesn't do arrays as you'd expect, so we'll need to apply the classes array from options separately
+        let moduleClasses = false;
+        if (options.modules) {
+            moduleClasses = options.modules.slice();
+        }
+
+        // Apply options to default options
         this.options = defaultsDeep({}, options, DefaultOptions);
 
-        // track resize handles
-        this.boxes = [];
+        // (see above about moduleClasses)
+        if (moduleClasses !== false) {
+            this.options.modules = moduleClasses;
+        }
 
         // disable native image resizing on firefox
         document.execCommand('enableObjectResizing', false, 'false');
 
         // respond to clicks inside the editor
         this.quill.root.addEventListener('click', this.handleClick, false);
+
+        // setup modules
+        this.moduleClasses = this.options.modules;
+
+        this.modules = [];
     }
+
+    initializeModules = () => {
+        this.removeModules();
+
+        this.modules = this.moduleClasses.map(
+            ModuleClass => new ModuleClass(this.overlay, this.img, this.options, this.onUpdate),
+        );
+
+        this.modules.forEach(
+            (module) => {
+                module.onCreate();
+            },
+        );
+
+        this.onUpdate();
+    };
+
+    onUpdate = () => {
+        this.repositionElements();
+        this.modules.forEach(
+            (module) => {
+                module.onUpdate();
+            },
+        );
+    };
+
+    removeModules = () => {
+        this.modules.forEach(
+            (module) => {
+                module.onDestroy();
+            },
+        );
+
+        this.modules = [];
+    };
 
     handleClick = (evt) => {
         if (evt.target && evt.target.tagName && evt.target.tagName.toUpperCase() === 'IMG') {
@@ -48,9 +103,7 @@ export default class ImageResize {
 
         this.showOverlay();
 
-        this.showToolbar();
-        this.showSizeDisplay();
-        this.showResizers();
+        this.initializeModules();
     };
 
     showOverlay = () => {
@@ -58,6 +111,14 @@ export default class ImageResize {
             this.hideOverlay();
         }
 
+        // prevent spurious text selection
+        this.setUserSelect('none');
+
+        // listen for the image being deleted or moved
+        document.addEventListener('keyup', this.checkImage, true);
+        this.quill.root.addEventListener('input', this.checkImage, true);
+
+        // Create and add the overlay
         this.overlay = document.createElement('div');
         Object.assign(this.overlay.style, this.options.overlayStyles);
 
@@ -71,8 +132,16 @@ export default class ImageResize {
             return;
         }
 
+        // Remove the overlay
         document.body.removeChild(this.overlay);
         this.overlay = undefined;
+
+        // stop listening for image deletion or movement
+        document.removeEventListener('keyup', this.checkImage);
+        this.quill.root.removeEventListener('input', this.checkImage);
+
+        // reset user-select
+        this.setUserSelect('');
     };
 
     repositionElements = () => {
@@ -89,119 +158,12 @@ export default class ImageResize {
             width: `${rect.width}px`,
             height: `${rect.height}px`,
         });
-
-        this.positionSizeDisplay();
     };
 
     hide = () => {
-        this.hideResizers();
-        this.hideSizeDisplay();
-        this.hideToolbar();
         this.hideOverlay();
+        this.removeModules();
         this.img = undefined;
-    };
-
-    showResizers = () => {
-        // prevent spurious text selection
-        this.setUserSelect('none');
-        // add 4 resize handles
-        this.addBox('nwse-resize'); // top left
-        this.addBox('nesw-resize'); // top right
-        this.addBox('nwse-resize'); // bottom right
-        this.addBox('nesw-resize'); // bottom left
-        // listen for the image being deleted or moved
-        document.addEventListener('keyup', this.checkImage, true);
-        this.quill.root.addEventListener('input', this.checkImage, true);
-        this.positionBoxes();
-    };
-
-    hideResizers = () => {
-        // stop listening for image deletion or movement
-        document.removeEventListener('keyup', this.checkImage);
-        this.quill.root.removeEventListener('input', this.checkImage);
-        // reset user-select
-        this.setUserSelect('');
-        this.setCursor('');
-        // remove boxes
-        this.boxes.forEach(box => box.parentNode.removeChild(box));
-        // release memory
-        this.dragBox = undefined;
-        this.dragStartX = undefined;
-        this.preDragWidth = undefined;
-        this.boxes = [];
-    };
-
-    addBox = (cursor) => {
-        // create div element for resize handle
-        const box = document.createElement('div');
-
-        // Star with the specified styles
-        Object.assign(box.style, this.options.handleStyles);
-        box.style.cursor = cursor;
-
-        // Set the width/height to use 'px'
-        box.style.width = `${this.options.handleStyles.width}px`;
-        box.style.height = `${this.options.handleStyles.height}px`;
-
-        // listen for mousedown on each box
-        box.addEventListener('mousedown', this.handleMousedown, false);
-        // add drag handle to document
-        this.overlay.appendChild(box);
-        // keep track of drag handle
-        this.boxes.push(box);
-    };
-
-    positionBoxes = () => {
-        const handleXOffset = `${-this.options.handleStyles.width / 2}px`;
-        const handleYOffset = `${-this.options.handleStyles.height / 2}px`;
-
-        // set the top and left for each drag handle
-        [
-            { left: handleXOffset, top: handleYOffset },        // top left
-            { right: handleXOffset, top: handleYOffset },       // top right
-            { right: handleXOffset, bottom: handleYOffset },    // bottom right
-            { left: handleXOffset, bottom: handleYOffset },     // bottom left
-        ].forEach((pos, idx) => {
-            Object.assign(this.boxes[idx].style, pos);
-        });
-    };
-
-    handleMousedown = (evt) => {
-        // note which box
-        this.dragBox = evt.target;
-        // note starting mousedown position
-        this.dragStartX = evt.clientX;
-        // store the width before the drag
-        this.preDragWidth = this.img.width || this.img.naturalWidth;
-        // set the proper cursor everywhere
-        this.setCursor(this.dragBox.style.cursor);
-        // listen for movement and mouseup
-        document.addEventListener('mousemove', this.handleDrag, false);
-        document.addEventListener('mouseup', this.handleMouseup, false);
-    };
-
-    handleMouseup = () => {
-        // reset cursor everywhere
-        this.setCursor('');
-        // stop listening for movement and mouseup
-        document.removeEventListener('mousemove', this.handleDrag);
-        document.removeEventListener('mouseup', this.handleMouseup);
-    };
-
-    handleDrag = (evt) => {
-        if (!this.img) {
-            // image not set yet
-            return;
-        }
-        // update image size
-        if (this.dragBox === this.boxes[0] || this.dragBox === this.boxes[3]) {
-            // left-side resize handler; dragging right shrinks image
-            this.img.width = Math.round((this.preDragWidth - evt.clientX) - this.dragStartX);
-        } else {
-            // right-side resize handler; dragging right enlarges image
-            this.img.width = Math.round((this.preDragWidth + evt.clientX) - this.dragStartX);
-        }
-        this.repositionElements();
     };
 
     setUserSelect = (value) => {
@@ -211,19 +173,9 @@ export default class ImageResize {
             'webkitUserSelect',
             'msUserSelect',
         ].forEach((prop) => {
-                // set on contenteditable element and <html>
+            // set on contenteditable element and <html>
             this.quill.root.style[prop] = value;
             document.documentElement.style[prop] = value;
-        });
-    };
-
-    setCursor = (value) => {
-        [
-            document.body,
-            this.img,
-            this.quill.root,
-        ].forEach((el) => {
-            el.style.cursor = value;   // eslint-disable-line no-param-reassign
         });
     };
 
@@ -231,185 +183,5 @@ export default class ImageResize {
         if (this.img) {
             this.hide();
         }
-    };
-
-    showSizeDisplay = () => {
-        if (!this.options.displaySize || !this.overlay) {
-            return;
-        }
-
-        // Create the container to hold the size display
-        this.display = document.createElement('div');
-
-        // Apply styles
-        Object.assign(this.display.style, this.options.displayStyles);
-
-        // Attach it
-        this.overlay.appendChild(this.display);
-        this.positionSizeDisplay();
-    };
-
-    hideSizeDisplay = () => {
-        if (this.display) {
-            this.display.parentNode.removeChild(this.display);
-        }
-        this.display = undefined;
-    };
-
-    positionSizeDisplay = () => {
-        if (!this.display || !this.img) {
-            return;
-        }
-
-        const size = this.getCurrentSize();
-        this.display.innerHTML = size.join(' &times; ');
-        if (size[0] > 120 && size[1] > 30) {
-            // position on top of image
-            Object.assign(this.display.style, {
-                top: 'initial',
-                left: 'initial',
-                bottom: 0,
-                right: 0,
-            });
-        } else {
-            // position off top right
-            const dispRect = this.display.getBoundingClientRect();
-            Object.assign(this.display.style, {
-                top: 0,
-                right: `-${dispRect.width}px`,
-                left: 'initial',
-                bottom: 'initial',
-            });
-        }
-    };
-
-    getCurrentSize = () => [
-        this.img.width,
-        Math.round((this.img.width / this.img.naturalWidth) * this.img.naturalHeight),
-    ];
-
-    showToolbar = () => {
-        if (this.options.displayToolbar === false) {
-            return;
-        }
-
-        this.toolbar = document.createElement('div');
-
-        this.addToolbarButtons();
-
-        // Apply styles
-        Object.assign(this.toolbar.style, this.options.toolbarStyles);
-
-        // Attach it
-        this.overlay.appendChild(this.toolbar);
-
-        this.positionToolbar();
-    };
-
-    positionToolbar = () => {
-        if (!this.toolbar || !this.img) {
-            return;
-        }
-
-        const dispRect = this.toolbar.getBoundingClientRect();
-
-        Object.assign(this.toolbar.style, {
-            left: 0,
-            bottom: `${-dispRect.height}px`,
-        });
-    };
-
-    addToolbarButtons = () => {
-        this.addAlignLeft();
-        this.addAlignCenter();
-        this.addAlignRight();
-    };
-
-    addAlignLeft = () => {
-        if (this.options.toolbarButtons.alignLeft === false) {
-            return;
-        }
-
-        const button = document.createElement('button');
-        button.innerHTML = 'Align left';
-        button.onclick = this.onAlignLeft;
-
-        this.toolbar.appendChild(button);
-    };
-
-    onAlignLeft = () => {
-        if (this.img.getAttribute('data-align') === 'left') {
-            this.clearAlignmentStyles();
-            return;
-        }
-
-        this.clearAlignmentStyles();
-        this.img.style.float = 'left';
-        this.img.setAttribute('data-align', 'left');
-        this.repositionElements();
-    };
-
-    addAlignRight = () => {
-        if (this.options.toolbarButtons.alignRight === false) {
-            return;
-        }
-
-        const button = document.createElement('button');
-        button.innerHTML = 'Align right';
-        button.onclick = this.onAlignRight;
-
-        this.toolbar.appendChild(button);
-    };
-
-    onAlignRight = () => {
-        if (this.img.getAttribute('data-align') === 'right') {
-            this.clearAlignmentStyles();
-            return;
-        }
-
-        this.clearAlignmentStyles();
-        this.img.style.float = 'right';
-        this.img.setAttribute('data-align', 'right');
-        this.repositionElements();
-    };
-
-    addAlignCenter = () => {
-        if (this.options.toolbarButtons.alignCenter === false) {
-            return;
-        }
-
-        const button = document.createElement('button');
-        button.innerHTML = 'Align center';
-        button.onclick = this.onAlignCenter;
-
-        this.toolbar.appendChild(button);
-    };
-
-    onAlignCenter = () => {
-        if (this.img.getAttribute('data-align') === 'center') {
-            this.clearAlignmentStyles();
-            return;
-        }
-
-        this.clearAlignmentStyles();
-        this.img.style.display = 'block';
-        this.img.style.margin = 'auto';
-        this.img.setAttribute('data-align', 'center');
-        this.repositionElements();
-    };
-
-    clearAlignmentStyles = () => {
-        this.img.style.display = 'inline-block';
-        this.img.style.margin = '';
-        this.img.style.float = '';
-        this.img.removeAttribute('data-align');
-        this.repositionElements();
-    };
-
-    hideToolbar = () => {
-        if (this.toolbar) {
-            this.toolbar.parentNode.removeChild(this.toolbar);
-        }
-        this.toolbar = undefined;
     };
 }

--- a/src/modules/BaseModule.js
+++ b/src/modules/BaseModule.js
@@ -1,0 +1,41 @@
+export default class BaseModule {
+    constructor(overlay, img, options, requestUpdate) {
+        this.overlay = overlay;
+        this.img = img;
+        this.options = options;
+        this.requestUpdate = requestUpdate;
+    }
+    /*
+        requestUpdate (passed in by the library during construction, above) can be used to let the library know that
+        you've changed something about the image that would require re-calculating the overlay (and all of its child
+        elements)
+
+        For example, if you add a margin to the element, you'll want to call this or else all the controls will be
+        misaligned on-screen.
+     */
+
+    /*
+        onCreate will be called when the element is clicked on
+
+        If the module has any user controls, it should create any containers that it'll need here.
+        The overlay has absolute positioning, and will be automatically repositioned and resized as needed, so you can
+        use your own absolute positioning and the 'top', 'right', etc. styles to be positioned relative to the element
+        on-screen.
+     */
+    onCreate = () => {};
+
+    /*
+        onDestroy will be called when the element is de-selected, or when this module otherwise needs to tidy up.
+
+        If you created any DOM elements in onCreate, please remove them from the DOM and destroy them here.
+     */
+    onDestroy = () => {};
+
+    /*
+        onUpdate will be called any time that the element is changed (e.g. resized, aligned, etc.)
+
+        This frequently happens during resize dragging, so keep computations light while here to ensure a smooth
+        user experience.
+     */
+    onUpdate = () => {};
+}

--- a/src/modules/DisplaySize.js
+++ b/src/modules/DisplaySize.js
@@ -1,0 +1,53 @@
+import BaseModule from './BaseModule';
+
+export default class DisplaySize extends BaseModule {
+    onCreate = () => {
+        // Create the container to hold the size display
+        this.display = document.createElement('div');
+
+        // Apply styles
+        Object.assign(this.display.style, this.options.displayStyles);
+
+        // Attach it
+        this.overlay.appendChild(this.display);
+    };
+
+    onDestroy = () => {
+        if (this.display) {
+            this.display.parentNode.removeChild(this.display);
+        }
+        this.display = undefined;
+    };
+
+    onUpdate = () => {
+        if (!this.display || !this.img) {
+            return;
+        }
+
+        const size = this.getCurrentSize();
+        this.display.innerHTML = size.join(' &times; ');
+        if (size[0] > 120 && size[1] > 30) {
+            // position on top of image
+            Object.assign(this.display.style, {
+                top: 'initial',
+                left: 'initial',
+                bottom: 0,
+                right: 0,
+            });
+        } else {
+            // position off top right
+            const dispRect = this.display.getBoundingClientRect();
+            Object.assign(this.display.style, {
+                top: 0,
+                right: `-${dispRect.width}px`,
+                left: 'initial',
+                bottom: 'initial',
+            });
+        }
+    };
+
+    getCurrentSize = () => [
+        this.img.width,
+        Math.round((this.img.width / this.img.naturalWidth) * this.img.naturalHeight),
+    ];
+}

--- a/src/modules/Resize.js
+++ b/src/modules/Resize.js
@@ -1,0 +1,110 @@
+import BaseModule from './BaseModule';
+
+export default class Resize extends BaseModule {
+    onCreate = () => {
+        // track resize handles
+        this.boxes = [];
+
+        // add 4 resize handles
+        this.addBox('nwse-resize'); // top left
+        this.addBox('nesw-resize'); // top right
+        this.addBox('nwse-resize'); // bottom right
+        this.addBox('nesw-resize'); // bottom left
+
+        this.positionBoxes();
+    };
+
+    onDestroy = () => {
+        // remove boxes
+        this.boxes.forEach(box => box.parentNode.removeChild(box));
+        this.setCursor('');
+
+        // release memory
+        this.dragBox = undefined;
+        this.dragStartX = undefined;
+        this.preDragWidth = undefined;
+        this.boxes = [];
+    };
+
+    positionBoxes = () => {
+        const handleXOffset = `${-this.options.handleStyles.width / 2}px`;
+        const handleYOffset = `${-this.options.handleStyles.height / 2}px`;
+
+        // set the top and left for each drag handle
+        [
+            { left: handleXOffset, top: handleYOffset },        // top left
+            { right: handleXOffset, top: handleYOffset },       // top right
+            { right: handleXOffset, bottom: handleYOffset },    // bottom right
+            { left: handleXOffset, bottom: handleYOffset },     // bottom left
+        ].forEach((pos, idx) => {
+            Object.assign(this.boxes[idx].style, pos);
+        });
+    };
+
+    addBox = (cursor) => {
+        // create div element for resize handle
+        const box = document.createElement('div');
+
+        // Star with the specified styles
+        Object.assign(box.style, this.options.handleStyles);
+        box.style.cursor = cursor;
+
+        // Set the width/height to use 'px'
+        box.style.width = `${this.options.handleStyles.width}px`;
+        box.style.height = `${this.options.handleStyles.height}px`;
+
+        // listen for mousedown on each box
+        box.addEventListener('mousedown', this.handleMousedown, false);
+        // add drag handle to document
+        this.overlay.appendChild(box);
+        // keep track of drag handle
+        this.boxes.push(box);
+    };
+
+    handleMousedown = (evt) => {
+        // note which box
+        this.dragBox = evt.target;
+        // note starting mousedown position
+        this.dragStartX = evt.clientX;
+        // store the width before the drag
+        this.preDragWidth = this.img.width || this.img.naturalWidth;
+        // set the proper cursor everywhere
+        this.setCursor(this.dragBox.style.cursor);
+        // listen for movement and mouseup
+        document.addEventListener('mousemove', this.handleDrag, false);
+        document.addEventListener('mouseup', this.handleMouseup, false);
+    };
+
+    handleMouseup = () => {
+        // reset cursor everywhere
+        this.setCursor('');
+        // stop listening for movement and mouseup
+        document.removeEventListener('mousemove', this.handleDrag);
+        document.removeEventListener('mouseup', this.handleMouseup);
+    };
+
+    handleDrag = (evt) => {
+        if (!this.img) {
+            // image not set yet
+            return;
+        }
+        // update image size
+        if (this.dragBox === this.boxes[0] || this.dragBox === this.boxes[3]) {
+            // left-side resize handler; dragging right shrinks image
+            this.img.width = Math.round((this.preDragWidth - evt.clientX) - this.dragStartX);
+        } else {
+            // right-side resize handler; dragging right enlarges image
+            this.img.width = Math.round((this.preDragWidth + evt.clientX) - this.dragStartX);
+        }
+        this.requestUpdate();
+    };
+
+    setCursor = (value) => {
+        [
+            document.body,
+            this.img,
+        ].forEach((el) => {
+            el.style.cursor = value;   // eslint-disable-line no-param-reassign
+        });
+    };
+}

--- a/src/modules/Toolbar.js
+++ b/src/modules/Toolbar.js
@@ -1,0 +1,123 @@
+import BaseModule from './BaseModule';
+
+export default class Toolbar extends BaseModule {
+    onCreate = () => {
+        this.toolbar = document.createElement('div');
+
+        this.addToolbarButtons();
+
+        // Apply styles
+        Object.assign(this.toolbar.style, this.options.toolbarStyles);
+
+        // Attach it
+        this.overlay.appendChild(this.toolbar);
+    };
+
+    onDestroy = () => {
+        if (this.toolbar) {
+            this.toolbar.parentNode.removeChild(this.toolbar);
+        }
+        this.toolbar = undefined;
+    };
+
+    onUpdate = () => {
+        if (!this.toolbar || !this.img) {
+            return;
+        }
+
+        const dispRect = this.toolbar.getBoundingClientRect();
+
+        Object.assign(this.toolbar.style, {
+            left: 0,
+            bottom: `${-dispRect.height}px`,
+        });
+    };
+
+    addToolbarButtons = () => {
+        this.addAlignLeft();
+        this.addAlignCenter();
+        this.addAlignRight();
+    };
+
+    addAlignLeft = () => {
+        if (this.options.toolbarButtons.alignLeft === false) {
+            return;
+        }
+
+        const button = document.createElement('button');
+        button.innerHTML = 'Align left';
+        button.onclick = this.onAlignLeft;
+
+        this.toolbar.appendChild(button);
+    };
+
+    onAlignLeft = () => {
+        if (this.img.getAttribute('data-align') === 'left') {
+            this.clearAlignmentStyles();
+            return;
+        }
+
+        this.clearAlignmentStyles();
+        this.img.style.float = 'left';
+        this.img.setAttribute('data-align', 'left');
+        this.requestUpdate();
+    };
+
+    addAlignRight = () => {
+        if (this.options.toolbarButtons.alignRight === false) {
+            return;
+        }
+
+        const button = document.createElement('button');
+        button.innerHTML = 'Align right';
+        button.onclick = this.onAlignRight;
+
+        this.toolbar.appendChild(button);
+    };
+
+    onAlignRight = () => {
+        if (this.img.getAttribute('data-align') === 'right') {
+            this.clearAlignmentStyles();
+            return;
+        }
+
+        this.clearAlignmentStyles();
+        this.img.style.float = 'right';
+        this.img.setAttribute('data-align', 'right');
+        this.requestUpdate();
+    };
+
+    addAlignCenter = () => {
+        if (this.options.toolbarButtons.alignCenter === false) {
+            return;
+        }
+
+        const button = document.createElement('button');
+        button.innerHTML = 'Align center';
+        button.onclick = this.onAlignCenter;
+
+        this.toolbar.appendChild(button);
+    };
+
+    onAlignCenter = () => {
+        if (this.img.getAttribute('data-align') === 'center') {
+            this.clearAlignmentStyles();
+            return;
+        }
+
+        this.clearAlignmentStyles();
+
+        this.img.style.display = 'block';
+        this.img.style.margin = 'auto';
+        this.img.setAttribute('data-align', 'center');
+        this.requestUpdate();
+    };
+
+    clearAlignmentStyles = () => {
+        this.img.style.display = 'inline-block';
+        this.img.style.margin = '';
+        this.img.style.float = '';
+        this.img.removeAttribute('data-align');
+        this.requestUpdate();
+    };
+}


### PR DESCRIPTION
For example, one could write a custom module that extends BaseModule, and include that in the Quill module configuration alongside the built-ins without necessarily needing to submit a PR and get their extension included in the library.

@Wikia/cake 